### PR TITLE
Add unit tests for resolver.py

### DIFF
--- a/python/tests/test_resolver.py
+++ b/python/tests/test_resolver.py
@@ -1,0 +1,23 @@
+import unittest
+from uagents.resolver import RulesBasedResolver
+
+class TestRulesBasedResolver(unittest.TestCase):
+    def setUp(self):
+        self.resolver = RulesBasedResolver(
+            rules={
+                "agent1qt0487g004xezsz8cte4827t7y847gzr5n6enwv6rrk09l0cjfl62rmnx79": ["http://localhost:8000/submit"]*15,
+            }
+        )
+
+    def test_resolve(self):
+        destination, endpoints = await self.resolver.resolve("agent1qt0487g004xezsz8cte4827t7y847gzr5n6enwv6rrk09l0cjfl62rmnx79")
+        self.assertEqual(len(endpoints), 10)
+        self.assertEqual(destination, "agent1qt0487g004xezsz8cte4827t7y847gzr5n6enwv6rrk09l0cjfl62rmnx79")
+
+        not_registered_agent = "agent1q992tl7j9062ussaunq6vp5p4qaqugkzp8pva3xlszmeg0533k952lz8alf"
+        destination2, endpoints2 = await self.resolver.resolve(not_registered_agent)
+        self.assertEqual(len(endpoints2), 0)
+        self.assertEqual(destination2, not_registered_agent)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/tests/test_resolver.py
+++ b/python/tests/test_resolver.py
@@ -1,8 +1,9 @@
+import asyncio
 import unittest
 from uagents.resolver import RulesBasedResolver
 
 
-class TestRulesBasedResolver(unittest.TestCase):
+class TestRulesBasedResolver(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.resolver = RulesBasedResolver(
             rules={
@@ -10,13 +11,13 @@ class TestRulesBasedResolver(unittest.TestCase):
             }
         )
 
-    def test_resolve_normal(self):
+    async def test_resolve_normal(self):
         expected_agent = "agent1qt0487g004xezsz8cte4827t7y847gzr5n6enwv6rrk09l0cjfl62rmnx79"
         destination, endpoints = await self.resolver.resolve(expected_agent)
         self.assertEqual(len(endpoints), 10)
         self.assertEqual(destination, expected_agent)
 
-    def test_resolve_not_registered(self):
+    async def test_resolve_not_registered(self):
         not_registered_agent = "agent1q992tl7j9062ussaunq6vp5p4qaqugkzp8pva3xlszmeg0533k952lz8alf"
         destination2, endpoints2 = await self.resolver.resolve(not_registered_agent)
         self.assertEqual(len(endpoints2), 0)

--- a/python/tests/test_resolver.py
+++ b/python/tests/test_resolver.py
@@ -1,6 +1,7 @@
 import unittest
 from uagents.resolver import RulesBasedResolver
 
+
 class TestRulesBasedResolver(unittest.TestCase):
     def setUp(self):
         self.resolver = RulesBasedResolver(
@@ -9,11 +10,13 @@ class TestRulesBasedResolver(unittest.TestCase):
             }
         )
 
-    def test_resolve(self):
-        destination, endpoints = await self.resolver.resolve("agent1qt0487g004xezsz8cte4827t7y847gzr5n6enwv6rrk09l0cjfl62rmnx79")
+    def test_resolve_normal(self):
+        expected_agent = "agent1qt0487g004xezsz8cte4827t7y847gzr5n6enwv6rrk09l0cjfl62rmnx79"
+        destination, endpoints = await self.resolver.resolve(expected_agent)
         self.assertEqual(len(endpoints), 10)
-        self.assertEqual(destination, "agent1qt0487g004xezsz8cte4827t7y847gzr5n6enwv6rrk09l0cjfl62rmnx79")
+        self.assertEqual(destination, expected_agent)
 
+    def test_resolve_not_registered(self):
         not_registered_agent = "agent1q992tl7j9062ussaunq6vp5p4qaqugkzp8pva3xlszmeg0533k952lz8alf"
         destination2, endpoints2 = await self.resolver.resolve(not_registered_agent)
         self.assertEqual(len(endpoints2), 0)


### PR DESCRIPTION
Add unit tests for the RulesBasedResolver in `python/src/uagents/resolver.py`.

Just test a few simple inputs and outputs and put the test cases in `python/tests/test_resolver.py`.

You can find an example of a RulesBasedResolver here: https://github.com/jrriehl/uAgents/blob/main/python/tests/test_context.py#L26-L33